### PR TITLE
Add AuthService and wire components

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
 import { RouterModule, Routes } from '@angular/router';
 
 import { AppComponent } from './app.component';
@@ -15,7 +16,7 @@ const routes: Routes = [
 
 @NgModule({
   declarations: [AppComponent, LoginComponent, RegisterComponent],
-  imports: [BrowserModule, FormsModule, RouterModule.forRoot(routes)],
+  imports: [BrowserModule, FormsModule, HttpClientModule, RouterModule.forRoot(routes)],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/frontend/src/app/auth.service.ts
+++ b/frontend/src/app/auth.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  private baseUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  login(data: { email: string; password: string; totpCode?: string }): Observable<any> {
+    return this.http.post(`${this.baseUrl}/login`, data);
+  }
+
+  register(data: { email: string; password: string; firstName: string; lastName: string }): Observable<any> {
+    return this.http.post(`${this.baseUrl}/register`, data);
+  }
+}

--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'app-login',
@@ -13,6 +14,8 @@ export class LoginComponent {
   password = '';
   totpCode = '';
 
+  constructor(private auth: AuthService) {}
+
   togglePassword(): void {
     this.showPassword = !this.showPassword;
   }
@@ -23,8 +26,14 @@ export class LoginComponent {
       alert("Veuillez entrer votre code d'authentification à deux facteurs");
       return;
     }
-    console.log({ email: this.email, password: this.password, totpCode: this.totpCode });
-    alert('Connexion réussie !');
+    this.auth.login({
+      email: this.email,
+      password: this.password,
+      totpCode: this.totpCode || undefined
+    }).subscribe({
+      next: () => alert('Connexion réussie !'),
+      error: () => alert('Erreur lors de la connexion')
+    });
   }
 
   loginWithGoogle(): void {

--- a/frontend/src/app/register/register.component.ts
+++ b/frontend/src/app/register/register.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'app-register',
@@ -9,6 +10,8 @@ export class RegisterComponent {
   step = 1;
   showPassword = false;
   showConfirm = false;
+
+  constructor(private auth: AuthService) {}
 
   formData = {
     email: '',
@@ -44,8 +47,17 @@ export class RegisterComponent {
       alert("Vous devez accepter les conditions d'utilisation");
       return;
     }
-    console.log('Données d\'inscription:', this.formData);
-    alert('Compte créé avec succès !');
-    this.goToStep(1);
+    this.auth.register({
+      email: this.formData.email,
+      password: this.formData.password,
+      firstName: this.formData.firstName,
+      lastName: this.formData.lastName
+    }).subscribe({
+      next: () => {
+        alert('Compte créé avec succès !');
+        this.goToStep(1);
+      },
+      error: () => alert('Erreur lors de la création du compte')
+    });
   }
 }

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: 'http://localhost:3000/api'
+};


### PR DESCRIPTION
## Summary
- create an `environment` folder with the API base URL
- add `AuthService` with `login` and `register` functions
- import `HttpClientModule` in `AppModule`
- update `LoginComponent` and `RegisterComponent` to call `AuthService`

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684677db6b98832eb0f46bbbc7d46154