### PR TITLE
Add Jasmine/Karma tests

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -28,6 +28,19 @@
           "options": {
             "browserTarget": "login-register-app:build"
           }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "inlineStyleLanguage": "css",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
         }
       }
     }

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -1,0 +1,20 @@
+const process = require('process');
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['ChromeHeadless'],
+    singleRun: true,
+    restartOnFileChange: true
+  });
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "ng serve",
-    "build": "ng build"
+    "build": "ng build",
+    "test": "ng test --watch=false"
   },
   "dependencies": {
     "@angular/animations": "^17.2.0",
@@ -21,6 +22,12 @@
   "devDependencies": {
     "@angular/cli": "^17.2.0",
     "@angular/compiler-cli": "^17.2.0",
+    "@angular-devkit/build-angular": "^17.2.0",
+    "jasmine-core": "^5.1.0",
+    "karma": "^6.4.0",
+    "karma-chrome-launcher": "^3.2.0",
+    "karma-jasmine": "^5.1.0",
+    "karma-jasmine-html-reporter": "^2.0.0",
     "typescript": "^5.2.0"
   }
 }

--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [LoginComponent],
+      imports: [FormsModule]
+    });
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle password visibility', () => {
+    expect(component.showPassword).toBeFalse();
+    component.togglePassword();
+    expect(component.showPassword).toBeTrue();
+  });
+
+  it('should enable 2FA when code missing', () => {
+    spyOn(window, 'alert');
+    component.handleLogin();
+    expect(component.show2FA).toBeTrue();
+    expect(window.alert).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/register/register.component.spec.ts
+++ b/frontend/src/app/register/register.component.spec.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { RegisterComponent } from './register.component';
+
+describe('RegisterComponent', () => {
+  let component: RegisterComponent;
+  let fixture: ComponentFixture<RegisterComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [RegisterComponent],
+      imports: [FormsModule]
+    });
+    fixture = TestBed.createComponent(RegisterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle password field', () => {
+    expect(component.showPassword).toBeFalse();
+    component.toggle('password');
+    expect(component.showPassword).toBeTrue();
+  });
+
+  it('should toggle confirm password field', () => {
+    expect(component.showConfirm).toBeFalse();
+    component.toggle('confirmPassword');
+    expect(component.showConfirm).toBeTrue();
+  });
+
+  it('should stay on step 1 when passwords do not match', () => {
+    spyOn(window, 'alert');
+    component.formData.password = 'a';
+    component.formData.confirmPassword = 'b';
+    component.handleStep1();
+    expect(window.alert).toHaveBeenCalled();
+    expect(component.step).toBe(1);
+  });
+
+  it('should proceed to step 2 when passwords match', () => {
+    component.formData.password = 'a';
+    component.formData.confirmPassword = 'a';
+    component.handleStep1();
+    expect(component.step).toBe(2);
+  });
+
+  it('should require terms acceptance', () => {
+    spyOn(window, 'alert');
+    component.formData.acceptTerms = false;
+    component.handleStep2();
+    expect(window.alert).toHaveBeenCalled();
+  });
+
+  it('should reset after successful registration', () => {
+    component.step = 2;
+    component.formData.acceptTerms = true;
+    component.handleStep2();
+    expect(component.step).toBe(1);
+  });
+});

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -1,0 +1,11 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+);

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": ["jasmine", "node"]
+  },
+  "files": [
+    "src/test.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Karma and Jasmine dependencies and config
- create LoginComponent and RegisterComponent tests
- wire up karma config and npm test script

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684677deb1ec832eba8941e061be7904