### PR TITLE
Add AuthService and backend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,29 @@ This repository contains a simple Angular frontend with login and register pages
 
 The frontend code is located in the `frontend/` directory. It provides two Angular components:
 
+
 - `LoginComponent` for user authentication
 - `RegisterComponent` for account creation
 
-A backend can be implemented with FastAPI and PostgreSQL (not included in this repository).
+Both components use an `AuthService` that sends requests to a FastAPI backend.
+
+## Backend requirements
+
+The expected backend runs [FastAPI](https://fastapi.tiangolo.com/) with a PostgreSQL database.
+Set a `DATABASE_URL` environment variable, for example:
+
+```bash
+export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mydb
+```
+
+Install the dependencies and start the API:
+
+```bash
+pip install fastapi[all] psycopg2-binary
+uvicorn main:app --reload
+```
+
+The frontend `AuthService` assumes the API is available at `http://localhost:8000`.
 
 To run the Angular application locally:
 

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
 import { RouterModule, Routes } from '@angular/router';
 
 import { AppComponent } from './app.component';
@@ -15,7 +16,7 @@ const routes: Routes = [
 
 @NgModule({
   declarations: [AppComponent, LoginComponent, RegisterComponent],
-  imports: [BrowserModule, FormsModule, RouterModule.forRoot(routes)],
+  imports: [BrowserModule, FormsModule, HttpClientModule, RouterModule.forRoot(routes)],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/frontend/src/app/auth.service.ts
+++ b/frontend/src/app/auth.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private apiUrl = 'http://localhost:8000/api';
+
+  constructor(private http: HttpClient) {}
+
+  login(data: { email: string; password: string; totpCode?: string }): Observable<any> {
+    return this.http.post(`${this.apiUrl}/login`, data);
+  }
+
+  register(data: { email: string; password: string; firstName: string; lastName: string }): Observable<any> {
+    return this.http.post(`${this.apiUrl}/register`, data);
+  }
+}

--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'app-login',
@@ -13,6 +14,8 @@ export class LoginComponent {
   password = '';
   totpCode = '';
 
+  constructor(private authService: AuthService) {}
+
   togglePassword(): void {
     this.showPassword = !this.showPassword;
   }
@@ -23,8 +26,12 @@ export class LoginComponent {
       alert("Veuillez entrer votre code d'authentification à deux facteurs");
       return;
     }
-    console.log({ email: this.email, password: this.password, totpCode: this.totpCode });
-    alert('Connexion réussie !');
+    this.authService
+      .login({ email: this.email, password: this.password, totpCode: this.totpCode })
+      .subscribe({
+        next: () => alert('Connexion réussie !'),
+        error: () => alert('Erreur lors de la connexion')
+      });
   }
 
   loginWithGoogle(): void {

--- a/frontend/src/app/register/register.component.ts
+++ b/frontend/src/app/register/register.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'app-register',
@@ -16,8 +17,10 @@ export class RegisterComponent {
     confirmPassword: '',
     firstName: '',
     lastName: '',
-    acceptTerms: false
+  acceptTerms: false
   };
+
+  constructor(private authService: AuthService) {}
 
   toggle(field: 'password' | 'confirmPassword'): void {
     if (field === 'password') {
@@ -44,8 +47,19 @@ export class RegisterComponent {
       alert("Vous devez accepter les conditions d'utilisation");
       return;
     }
-    console.log('Données d\'inscription:', this.formData);
-    alert('Compte créé avec succès !');
-    this.goToStep(1);
+    this.authService
+      .register({
+        email: this.formData.email,
+        password: this.formData.password,
+        firstName: this.formData.firstName,
+        lastName: this.formData.lastName
+      })
+      .subscribe({
+        next: () => {
+          alert('Compte créé avec succès !');
+          this.goToStep(1);
+        },
+        error: () => alert("Erreur lors de l'inscription")
+      });
   }
 }


### PR DESCRIPTION
## Summary
- document FastAPI/PostgreSQL backend configuration in README
- add new `AuthService` to handle login/register requests
- wire login and register components to use `AuthService`
- import `HttpClientModule` in `AppModule`

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684677e334cc832ebce949f2596c11ec