### PR TITLE
Add Angular unit tests

### DIFF
--- a/frontend/src/app/login/login.component.spec.ts
+++ b/frontend/src/app/login/login.component.spec.ts
@@ -1,15 +1,22 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { of } from 'rxjs';
 import { LoginComponent } from './login.component';
+import { AuthService } from '../auth.service';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
 
   beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['login']);
+    authServiceSpy.login.and.returnValue(of({}));
+
     TestBed.configureTestingModule({
       declarations: [LoginComponent],
-      imports: [FormsModule]
+      imports: [FormsModule],
+      providers: [{ provide: AuthService, useValue: authServiceSpy }]
     });
     fixture = TestBed.createComponent(LoginComponent);
     component = fixture.componentInstance;
@@ -29,6 +36,7 @@ describe('LoginComponent', () => {
   it('should enable 2FA when code missing', () => {
     spyOn(window, 'alert');
     component.handleLogin();
+    expect(authServiceSpy.login).not.toHaveBeenCalled();
     expect(component.show2FA).toBeTrue();
     expect(window.alert).toHaveBeenCalled();
   });

--- a/frontend/src/app/register/register.component.spec.ts
+++ b/frontend/src/app/register/register.component.spec.ts
@@ -1,15 +1,22 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { of } from 'rxjs';
 import { RegisterComponent } from './register.component';
+import { AuthService } from '../auth.service';
 
 describe('RegisterComponent', () => {
   let component: RegisterComponent;
   let fixture: ComponentFixture<RegisterComponent>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
 
   beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['register']);
+    authServiceSpy.register.and.returnValue(of({}));
+
     TestBed.configureTestingModule({
       declarations: [RegisterComponent],
-      imports: [FormsModule]
+      imports: [FormsModule],
+      providers: [{ provide: AuthService, useValue: authServiceSpy }]
     });
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;
@@ -53,12 +60,14 @@ describe('RegisterComponent', () => {
     component.formData.acceptTerms = false;
     component.handleStep2();
     expect(window.alert).toHaveBeenCalled();
+    expect(authServiceSpy.register).not.toHaveBeenCalled();
   });
 
   it('should reset after successful registration', () => {
     component.step = 2;
     component.formData.acceptTerms = true;
     component.handleStep2();
+    expect(authServiceSpy.register).toHaveBeenCalled();
     expect(component.step).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add AuthService stubs for login and register component tests
- ensure tests check service interaction

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684679f7ebec832eb6747600767e1c67